### PR TITLE
Add simple Pacman features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Pacman Clone
+# Pacman Mania
 
-This project contains a very simple Pacman clone built with [Phaser 3](https://phaser.io/).
-
-Open `index.html` in your web browser to start the game. Use the arrow keys to move Pacman around the maze and eat the pellets. This is just the beginning of a clone and can be extended with ghosts, scoring and more levels.
+A simple Pacman style game built with [Phaser 3](https://phaser.io/).
+Open `index.html` in your browser and use the arrow keys to move Pacman one tile at a time.
+Eat all the pellets before the ghosts catch you or the timer runs out.

--- a/index.html
+++ b/index.html
@@ -2,10 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Pacman Clone</title>
+  <title>Pacman Mania</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
   <style>
-    body { margin: 0; }
+    body {
+      margin: 0;
+      background: #000;
+      color: #fff;
+      font-family: 'Press Start 2P', cursive;
+      text-align: center;
+    }
     canvas { display: block; margin: 0 auto; }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- enlarge board and render with tiles
- move player one tile at a time
- add roaming ghosts
- add scoring and countdown timer
- implement win and game over screens
- restyle page with arcade font

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d9393ec54832ba07321dc7fa5f83c